### PR TITLE
Update README to use local react-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ And then either start the app in Android and/or iOS using:
 ### Android emulator
 
 ```
-react-native run-android
+yarn android
 ```
 
 ### iOS simulator
 
 ```
-react-native run-ios
+yarn ios
 ```


### PR DESCRIPTION
While the readme is technically correct it assumes a globally installed version of the CLI. Since we already have npm scripts for running the commands we can use them instead of e.g. `./node_modules/.bin/react-native run-ios` or `npx react-native run-ios`