### PR TITLE
Added testing capabilities with React Testing Library

### DIFF
--- a/.github/workflows/prCheck.yaml
+++ b/.github/workflows/prCheck.yaml
@@ -26,3 +26,6 @@ jobs:
 
       - name: Check linting
         run: yarn lint
+
+      - name: Run tests
+        run: yarn test

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "@babel/core": "^7.8.4",
     "@babel/runtime": "^7.8.4",
     "@react-native-community/eslint-config": "^1.1.0",
+    "@testing-library/react": "^13.3.0",
+    "@testing-library/react-native": "^11.0.0",
     "@types/jest": "^25.2.3",
     "@types/react-native": "^0.63.2",
     "@types/react-native-vector-icons": "^4.6.4",
@@ -47,6 +49,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.21.3",
     "eslint-plugin-react-hooks": "^4.1.2",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^25.1.0",
     "metro-react-native-babel-preset": "^0.59.0",
     "prettier": "^2.1.2",
@@ -62,6 +65,14 @@
       "jsx",
       "json",
       "node"
-    ]
+    ],
+    "modulePathIgnorePatterns": ["./src/Utils/test.tsx"],
+    "setupFiles": [
+      "./setupTests.js",
+      "./node_modules/react-native-gesture-handler/jestSetup.js"
+    ],
+    "moduleNameMapper": {
+      ".+\\.(png|jpg|jpeg|webp)$": "identity-obj-proxy"
+    }
   }
 }

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,0 +1,6 @@
+jest.mock('react-native-reanimated', () => {
+  return {
+    // @ts-ignore
+    ...jest.requireActual('react-native-reanimated/mock'),
+  }
+})

--- a/src/Components/TextInputs.tsx
+++ b/src/Components/TextInputs.tsx
@@ -8,10 +8,10 @@ import {
   TextStyle,
   InteractionManager,
 } from 'react-native'
-import {useFocusEffect, useIsFocused} from '@react-navigation/native'
 import {Colors} from '~/Colors'
 import {Font, FontWeight} from '~/Font'
 import {Icons} from '~/Icons'
+import {useFocusEffect, useIsFocused} from '~/Navigation'
 import {IconButton} from './Buttons'
 
 const styles = StyleSheet.create({

--- a/src/Navigation/index.ts
+++ b/src/Navigation/index.ts
@@ -1,2 +1,21 @@
+import {RouteProp, useNavigation, useRoute} from '@react-navigation/native'
+import type {StackNavigationProp} from '@react-navigation/stack'
+import type {Routes} from './Routes'
+
 export * from './BackButton'
 export * from './Options'
+export * from './Routes'
+export * from '@react-navigation/native'
+
+type RootNavigation = StackNavigationProp<RootStackParamList>
+
+export type RootStackParamList = {
+  [Routes.START]: undefined
+  [Routes.CHANGE_NAME]: {name: string}
+}
+
+const useTypedNavigation = () => useNavigation<RootNavigation>()
+const useTypedRoute = <T extends Routes>() => useRoute<RouteProp<RootStackParamList, T>>()
+
+export {useTypedNavigation as useNavigation}
+export {useTypedRoute as useRoute}

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,26 +1,23 @@
-import {DefaultTheme, NavigationContainer, RouteProp} from '@react-navigation/native'
-import {createStackNavigator, StackNavigationProp} from '@react-navigation/stack'
+import {createStackNavigator} from '@react-navigation/stack'
 import React, {useEffect} from 'react'
 import {StatusBar} from 'react-native'
 import {SafeAreaProvider} from 'react-native-safe-area-context'
 import SplashScreen from 'react-native-splash-screen'
 import {Provider} from 'react-redux'
 import {PersistGate} from 'redux-persist/integration/react'
-import {ChangeName} from '~/ChangeName'
+import {ChangeName} from '~/Screens/ChangeName'
 import {Colors} from '~/Colors'
-import {defaultNavigationOptions} from '~/Navigation'
-import {Routes} from '~/Navigation/Routes'
-import {Start} from '~/Start'
+import {
+  defaultNavigationOptions,
+  DefaultTheme,
+  NavigationContainer,
+  RootStackParamList,
+  Routes,
+} from '~/Navigation'
+import {Start} from '~/Screens/Start'
 import {store, persistor} from '~/State'
 
-export type RootStackParamList = {
-  [Routes.START]: undefined
-  [Routes.CHANGE_NAME]: {name: string}
-}
 const Stack = createStackNavigator<RootStackParamList>()
-
-export type RootNavigation = StackNavigationProp<RootStackParamList>
-export type ChangeNameRouteProp = RouteProp<RootStackParamList, Routes.CHANGE_NAME>
 
 const RootStack: React.FC = () => {
   return (

--- a/src/Screens/ChangeName.tsx
+++ b/src/Screens/ChangeName.tsx
@@ -1,8 +1,9 @@
-import React, {useState} from 'react'
+import React, {ReactElement, useState} from 'react'
 import {StyleSheet, View} from 'react-native'
 import {useDispatch} from 'react-redux'
 import {PrimaryBlueButton, TextInput} from '~/Components'
-import type {ChangeNameRouteProp, RootNavigation} from '~/Root'
+import {Routes, useNavigation, useRoute} from '~/Navigation'
+
 import {changeName} from '~/State'
 
 const styles = StyleSheet.create({
@@ -15,13 +16,13 @@ const styles = StyleSheet.create({
   },
 })
 
-type ChangeNameProps = {
-  navigation: RootNavigation
-  route: ChangeNameRouteProp
-}
-export const ChangeName: React.FC<ChangeNameProps> = ({navigation, route}) => {
+export const ChangeName = (): ReactElement => {
   const dispatch = useDispatch()
+  const navigation = useNavigation()
+  const route = useRoute<Routes.CHANGE_NAME>()
+
   const [name, setName] = useState(route.params.name)
+
   return (
     <View style={styles.container}>
       <TextInput value={name} onChangeText={setName} />

--- a/src/Screens/Start/Start.test.tsx
+++ b/src/Screens/Start/Start.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import {userInitialState} from '~/State'
+import {render} from '~/Utils/test'
+import {Start} from './Start'
+
+it('should greet the user', async () => {
+  const {findByText} = render(<Start />)
+
+  const header = await findByText(`Hello ${userInitialState.name}!`)
+
+  expect(header).toBeDefined()
+})

--- a/src/Screens/Start/Start.tsx
+++ b/src/Screens/Start/Start.tsx
@@ -1,12 +1,11 @@
-import React from 'react'
+import React, {ReactElement} from 'react'
 import {StyleSheet, View} from 'react-native'
 import {SafeAreaView} from 'react-native-safe-area-context'
 import {useSelector} from 'react-redux'
 import {Colors} from '~/Colors'
 import {Body, H1, SecondaryBlueButton} from '~/Components'
-import {Routes} from '~/Navigation/Routes'
-import type {RootNavigation} from '~/Root'
 import {nameSelector} from '~/State'
+import {Routes, useNavigation} from '~/Navigation'
 
 const styles = StyleSheet.create({
   background: {
@@ -27,11 +26,10 @@ const styles = StyleSheet.create({
   },
 })
 
-type StartProps = {
-  navigation: RootNavigation
-}
-export const Start: React.FC<StartProps> = ({navigation}) => {
+export const Start = (): ReactElement => {
   const name = useSelector(nameSelector)
+  const navigation = useNavigation()
+
   return (
     <SafeAreaView style={styles.background} edges={['top']}>
       <View style={styles.content}>

--- a/src/Screens/Start/index.ts
+++ b/src/Screens/Start/index.ts
@@ -1,0 +1,1 @@
+export * from './Start'

--- a/src/State/User/index.ts
+++ b/src/State/User/index.ts
@@ -11,14 +11,14 @@ type UserState = {
   name: string
 }
 
-const initialState: UserState = {
+export const userInitialState: UserState = {
   name: 'Elsa',
   medications: [],
 }
 
 export const userSlice = createSlice({
   name: 'user',
-  initialState,
+  initialState: userInitialState,
   reducers: {
     changeName: (state, {payload: name}: PayloadAction<string>) => ({
       ...state,
@@ -27,7 +27,7 @@ export const userSlice = createSlice({
     addMedication: (state, {payload: name}: PayloadAction<string>) => {
       state.medications.push({name, addedAt: new Date().toISOString()})
     },
-    cleanState: () => initialState,
+    cleanState: () => userInitialState,
   },
 })
 

--- a/src/Utils/test.tsx
+++ b/src/Utils/test.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import {render} from '@testing-library/react-native'
+import {Provider} from 'react-redux'
+import {store} from '~/State'
+import {defaultNavigationOptions, NavigationContainer, Routes} from '~/Navigation'
+import {createStackNavigator} from '@react-navigation/stack'
+
+import type {ReactElement, ReactNode} from 'react'
+import type {RenderOptions} from '@testing-library/react'
+import type {RootStackParamList} from '~/Navigation'
+
+const Stack = createStackNavigator<RootStackParamList>()
+
+const Wrapper = ({children}: {children: ReactNode}) => (
+  <NavigationContainer>
+    <Stack.Navigator
+      headerMode="screen"
+      screenOptions={{
+        ...defaultNavigationOptions,
+      }}>
+      <Stack.Screen
+        name={Routes.START}
+        // eslint-disable-next-line react/no-children-prop
+        children={() => <Provider store={store}>{children}</Provider>}
+      />
+    </Stack.Navigator>
+  </NavigationContainer>
+)
+
+const decoratedRender = (ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) =>
+  render(ui, {wrapper: Wrapper, ...options})
+
+export * from '@testing-library/react-native'
+export {decoratedRender as render}

--- a/yarn.lock
+++ b/yarn.lock
@@ -687,7 +687,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.9.2":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.9.2":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
   integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
@@ -918,6 +918,13 @@
     v8-to-istanbul "^4.1.3"
   optionalDependencies:
     node-notifier "^6.0.0"
+
+"@jest/schemas@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-28.1.3.tgz#ad8b86a66f11f33619e3d7e1dcddd7f2d40ff905"
+  integrity sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==
+  dependencies:
+    "@sinclair/typebox" "^0.24.1"
 
 "@jest/source-map@^24.9.0":
   version "24.9.0"
@@ -1201,12 +1208,52 @@
     redux-thunk "^2.4.1"
     reselect "^4.1.5"
 
+"@sinclair/typebox@^0.24.1":
+  version "0.24.28"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.28.tgz#15aa0b416f82c268b1573ab653e4413c965fe794"
+  integrity sha512-dgJd3HLOkLmz4Bw50eZx/zJwtBq65nms3N9VBYu5LTjJ883oBFkTyXRlCB/ZGGwqYpJJHA5zW2Ibhl5ngITfow==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
   integrity sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==
   dependencies:
     type-detect "4.0.8"
+
+"@testing-library/dom@^8.5.0":
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.17.1.tgz#2d7af4ff6dad8d837630fecd08835aee08320ad7"
+  integrity sha512-KnH2MnJUzmFNPW6RIKfd+zf2Wue8mEKX0M3cpX6aKl5ZXrJM1/c/Pc8c2xDNYQCnJO48Sm5ITbMXgqTr3h4jxQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
+"@testing-library/react-native@^11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-11.0.0.tgz#604cd14a42331ce01f2b3695aeb9abf73940183b"
+  integrity sha512-2WZF8P8YYXO5Ka1yzj3TZUg4x6noKU5RuCpx4oAhKBkxkVbrRl1pMCvRIozdTPSiru4rNBmAi074ZJjm2OED5g==
+  dependencies:
+    pretty-format "^28.1.3"
+
+"@testing-library/react@^13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-13.3.0.tgz#bf298bfbc5589326bbcc8052b211f3bb097a97c5"
+  integrity sha512-DB79aA426+deFgGSjnf5grczDPiL4taK3hFaa+M5q7q20Kcve9eQottOG5kZ74KEr55v0tU2CQormSSDK87zYQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^8.5.0"
+    "@types/react-dom" "^18.0.0"
+
+"@types/aria-query@^4.2.0":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
+  integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
 "@types/babel__core@^7.1.7":
   version "7.1.10"
@@ -1323,6 +1370,13 @@
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react-dom@^18.0.0":
+  version "18.0.6"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
+  integrity sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-native-vector-icons@^4.6.4":
   version "4.6.4"
@@ -1568,6 +1622,11 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -1581,6 +1640,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 ansi-wrap@0.1.0, ansi-wrap@^0.1.0:
   version "0.1.0"
@@ -1609,6 +1673,11 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+aria-query@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
+  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
 
 arr-diff@^1.0.1:
   version "1.1.0"
@@ -2545,6 +2614,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-accessibility-api@^0.5.9:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz#56082f71b1dc7aac69d83c4285eef39c15d93f56"
+  integrity sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==
+
 domexception@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
@@ -3437,6 +3511,11 @@ har-validator@~5.1.3:
     ajv "^6.12.3"
     har-schema "^2.0.0"
 
+harmony-reflect@^1.4.6:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.2.tgz#31ecbd32e648a34d030d86adb67d4d47547fe710"
+  integrity sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -3569,6 +3648,13 @@ iconv-lite@^0.6.2:
   integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
+
+identity-obj-proxy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
+  integrity sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==
+  dependencies:
+    harmony-reflect "^1.4.6"
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -4735,6 +4821,11 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
+
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -5807,6 +5898,25 @@ pretty-format@^25.1.0, pretty-format@^25.2.0, pretty-format@^25.2.1, pretty-form
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-28.1.3.tgz#c9fba8cedf99ce50963a11b27d982a9ae90970d5"
+  integrity sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==
+  dependencies:
+    "@jest/schemas" "^28.1.3"
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -5902,6 +6012,16 @@ react-is@^16.12.0, react-is@^16.13.0, react-is@^16.7.0, react-is@^16.8.1, react-
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-is@^18.0.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
 react-native-gesture-handler@1.6.1:
   version "1.6.1"


### PR DESCRIPTION
This PR introduces the possibility to write tests using React Testing Library. Changes to properly do so(or to simplify it):
- Mocking of image imports using `identity-obj-proxy`
- Mocking of `react-native-gesture-handler` according to: https://docs.swmansion.com/react-native-gesture-handler/docs/1.10.3/#testing
- Mocking of `react-native-reanimated` according to: https://docs.swmansion.com/react-native-reanimated/docs/1.x.x/getting_started/#testing
- Use /Navigation as a single entry point for everything navigation/`@react-navigation/native`
    - Introduction of two typed hooks, `useNavigation` and `useRoute`. By using these, navigation and/or routes does not have to be typed in every component
- Use `src/Utils/test.tsx` as a single entry point for everything testing/`@testing-library/react-native`
    - Introduction of a custom renderer that already has the navigation and Redux store set up
    
The PR-check workflow now also runs the tests, in addition to the previous linting